### PR TITLE
Update to GNOME 49 and various fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TMPFILES_CONF := 99-ideapad.conf
 subprojects:
 	@git submodule update --resursive
 
-template.ui: subprojects
+template.ui: subprojects template.blp
 	@./subprojects/blueprint-compiler/blueprint-compiler.py compile template.blp > template.ui
 
 $(EXTENSION_ZIP): template.ui

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,18 @@
 EXTENSION_ZIP := ideapad-controls@woomymy.protonmail.com.shell-extension.zip
 TMPFILES_CONF := 99-ideapad.conf
 
+all: extension_zip
+extension_zip: $(EXTENSION_ZIP)
+
 subprojects:
-	@git submodule update --resursive
+	git submodule update --resursive
 
 template.ui: subprojects template.blp
-	@./subprojects/blueprint-compiler/blueprint-compiler.py compile template.blp > template.ui
+	./subprojects/blueprint-compiler/blueprint-compiler.py compile template.blp > template.ui
 
-$(EXTENSION_ZIP): template.ui
-	@gnome-extensions pack ./ \
-    	--extra-source=template.ui \
+$(EXTENSION_ZIP): extension.js prefs.js metadata.json template.ui optionsUtils.js menus.js icons/ LICENSE.md po/
+	gnome-extensions pack ./ \
+		--extra-source=template.ui \
 		--extra-source=optionsUtils.js \
 		--extra-source=menus.js \
 		--extra-source=icons/ \
@@ -18,7 +21,7 @@ $(EXTENSION_ZIP): template.ui
 		--force
 
 translations:
-	@xgettext \
+	xgettext \
 		--files-from=po/POTFILES \
 		--output=po/ideapad-controls.pot \
 		--from-code=UTF-8 \
@@ -38,7 +41,4 @@ tmpfiles-install: $(TMPFILES_CONF)
 
 clean:
 	rm -f $(EXTENSION_ZIP) template.ui
-
-all: extension_zip
-extension_zip: $(EXTENSION_ZIP)
 

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,6 @@ tmpfiles-install: $(TMPFILES_CONF)
 clean:
 	rm -f $(EXTENSION_ZIP) template.ui
 
-all: install
+all: extension_zip
 extension_zip: $(EXTENSION_ZIP)
 

--- a/extension.js
+++ b/extension.js
@@ -136,8 +136,10 @@ export default class IdeapadControlsExtension extends Extension {
             status = writeStringToFile(destinationValue, destinationFile);
         }                
 
-        if (status && this.settings.get_boolean('send-success-notifications')) {
-            notify(_("Ideapad Controls"), notificationBody);
+        if (status) {
+            if (this.settings.get_boolean('send-success-notifications')) {
+                notify(_("Ideapad Controls"), notificationBody);
+            }
         } else {
             notify(_("Ideapad Controls"), _("Failed to enable %s").format(_(getOptionName(optionFile))));
         }

--- a/extension.js
+++ b/extension.js
@@ -109,9 +109,16 @@ export default class IdeapadControlsExtension extends Extension {
     // Read option value from driver file.
     getOptionValue(sysfsPath, optionFile) {
         const file = Gio.File.new_for_path(sysfsPath + optionFile);
-        const [success, contents] = file.load_contents(null);
-        if (!success) {
-            console.error(`Can't write ${optionFile}`);
+        let contents;
+        try {
+            let success;
+            [success, contents] = file.load_contents(null);
+            if (!success) {
+                console.error(`Could not read ${optionFile}`);
+                return '0';
+            }
+        } catch (e) {
+            console.error(`Could not read ${optionFile}: ${e}`);
             return '0';
         }
 

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "description": "Control Lenovo IdeaPad laptops options: Conservation Mode, Camera Lock, Fn Lock, Touchpad Lock, USB charging",
   "url": "https://github.com/Woomymy/ideapad-controls-gnome-extension",
   "shell-version": [
-    "45", "46", "47", "48"
+    "45", "46", "47", "48", "49"
   ],
   "version": 20,
   "settings-schema": "org.gnome.shell.extensions.ideapad-controls",

--- a/template.ui
+++ b/template.ui
@@ -54,7 +54,7 @@ corresponding .blp file and regenerate this file with blueprint-compiler.
         <child>
           <object class="AdwActionRow" id="pkexec_button_row">
             <property name="title" translatable="yes">Use pkexec</property>
-            <property name="subtitle" translatable="yes">Enable to make ideapad_laptop wrap its write commands with pkexec to request root privileges. Disable only if you have a proper permissions setup (see README for more details)</property>
+            <property name="subtitle" translatable="yes">Enable to make ideapad_laptop wrap its write commands with pkexec to request root privileges.</property>
             <child>
               <object class="GtkSwitch" id="pkexec_button_switch">
                 <property name="valign">3</property>


### PR DESCRIPTION
I rely on this extension in my day to day, and as Arch Linux recently updated to GNOME 49, I figured I could try to update this extension myself. The update was apparently as easy as adding 49 to the supported versions, but in the process I found a number of other issues and edge cases that I wanted to fix. I decided to bundle them all into one pull request in the hopes that you might agree with all of them, but if you prefer I can also split them into separate requests.

Each commit should be fairly small and easy-ish to review, but here is a compiled list of each change with some more detail:

- Add "49" to the list of supported versions.
- Fix an issue where disabling `send-success-notification` would instead always send the "Failed to enable..." notification, even when successful.
- Make the "Failed to enable..." notification actually show when changing an option fails.  
  This required properly handling the returned value of async functions used in `setOptionValue`.
- Fix a crash when the `sysfs-path` configuration is not valid.  
  The function `getOptionValue` still tries to read from that path if regenerating the menu (such as when the extension starts or switches from tray to system menu). This resulted in an uncaught exception, crashing the extension.
- Update 'template.ui' to match 'template.blp' from which it is generated.
- Change Makefile to match convention and contain all the dependencies between targets.  
  This change only affects developers, but should help avoid mistakes that happened to me during development, such as running `make install` without rebuilding the actual extension zip file from the current source.

Let me know if there are any questions or changes necessary.